### PR TITLE
Fix integer overflow currentLevelKnownBits in PICC_Select

### DIFF
--- a/MFRC522.cpp
+++ b/MFRC522.cpp
@@ -546,7 +546,7 @@ byte MFRC522::PICC_Select(	Uid *uid,			///< Pointer to Uid struct. Normally outp
   byte count;
   byte index;
   byte uidIndex;					// The first index in uid->uidByte[] that is used in the current Cascade Level.
-  char currentLevelKnownBits;		// The number of known UID bits in the current Cascade Level.
+  signed char currentLevelKnownBits;		// The number of known UID bits in the current Cascade Level.
   byte buffer[9];					// The SELECT/ANTICOLLISION commands uses a 7 byte standard frame + 2 bytes CRC_A
   byte bufferUsed;				// The number of bytes used in the buffer, ie the number of bytes to transfer to the FIFO.
   byte rxAlign;					// Used in BitFramingReg. Defines the bit position for the first bit received.


### PR DESCRIPTION
This fixes an integer overflow that can occur on [line 616](https://github.com/paguz/RPi-RFID/blob/4994fbff2fbb2494e366abc2e049c25983b057a6/MFRC522.cpp#L616) when uidIndex is higher than 0.

This makes the type of `currentLevelKnownBits` equal to the `int8_t` type used in the original library.

Thank you for making this library compatible with Raspberry PI by the way, it was very useful to me.